### PR TITLE
fix: unregister Sensor Listener on onDetachedFromEngine

### DIFF
--- a/android/src/main/kotlin/io/bitbunny/daily_pedometer/daily_pedometer/DailyPedometerPlugin.kt
+++ b/android/src/main/kotlin/io/bitbunny/daily_pedometer/daily_pedometer/DailyPedometerPlugin.kt
@@ -7,6 +7,7 @@ import android.util.Log
 /** DailyPedometerPlugin */
 class DailyPedometerPlugin: FlutterPlugin {
   private lateinit var stepCountChannel: EventChannel
+  private lateinit var stepCountHandler: SensorStreamHandler
 
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     Log.d("DailyPedometerPlugin", "onAttachedToEngine called");
@@ -15,15 +16,16 @@ class DailyPedometerPlugin: FlutterPlugin {
     stepCountChannel = EventChannel(flutterPluginBinding.binaryMessenger, "daily_step_count")
 
     /// Create handlers
-    val stepCountHandler = SensorStreamHandler(flutterPluginBinding)
+    stepCountHandler = SensorStreamHandler(flutterPluginBinding)
 
     /// Set handlers
     stepCountChannel.setStreamHandler(stepCountHandler)
 
-    
+
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     stepCountChannel.setStreamHandler(null)
+    stepCountHandler.dispose()
   }
 }

--- a/android/src/main/kotlin/io/bitbunny/daily_pedometer/daily_pedometer/SensorStreamHandler.kt
+++ b/android/src/main/kotlin/io/bitbunny/daily_pedometer/daily_pedometer/SensorStreamHandler.kt
@@ -38,6 +38,10 @@ class SensorStreamHandler() : EventChannel.StreamHandler {
     }
 
     override fun onCancel(arguments: Any?) {
+        dispose();
+    }
+
+    fun dispose() {
         sensorManager!!.unregisterListener(sensorEventListener);
     }
 


### PR DESCRIPTION
플러그인이 Flutter 엔진에서 detach될때, SensorListener도 해제하도록 수정 